### PR TITLE
chore: Remove 'openid' scope from Keycloak action URL

### DIFF
--- a/lua/ipax.lua
+++ b/lua/ipax.lua
@@ -173,7 +173,6 @@ local function get_kc_user_action_url(ipax_base_url, client_id, kc_action, autho
 	local params = {
 		client_id = client_id,
 		response_type = "code",
-		scope = "openid",
 		redirect_uri = redirect_uri,
 		kc_action = kc_action
 	}


### PR DESCRIPTION
The 'openid' scope is not required for the specific Keycloak user action, simplifying the authorization request.